### PR TITLE
[Feature] Allow users to set the queue priority

### DIFF
--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -42,6 +42,8 @@ class SettingsModel extends Model
      */
     public $combinedSettingsCheckMethod = '';
 
+    public $combinedSettingsQueuePriority = 1024;
+
     /**
      * @return array
      */
@@ -53,6 +55,7 @@ class SettingsModel extends Model
             [['combinedSettingsGlobals'], 'checkCombinedSettingsGlobals'],
             [['combinedSettingsAssets'], 'checkCombinedSettingsAssets'],
             [['combinedSettingsCheckMethod'], 'in', 'range' => ['and', 'or', 'xor']],
+            [['combinedSettingsQueuePriority'], 'checkCombinedSettingsQueuePriority']
         ];
     }
 
@@ -104,6 +107,11 @@ class SettingsModel extends Model
         $this->checkCombinedSettings('combinedSettingsAssets', SiteCopy::getCriteriaFieldsAssets());
     }
 
+    public function checkCombinedSettingsQueuePriority()
+    {
+        $this->checkCombinedSettings('combinedSettingsQueuePriority', []);
+    }
+
     public function checkCombinedSettings(string $attribute, array $criteriaFields)
     {
         $operators = SiteCopy::getOperators();
@@ -117,9 +125,13 @@ class SettingsModel extends Model
             }, $operators),
         ];
 
-        if (!is_array($this->{$attribute})) {
+        if ($attribute === 'combinedSettingsQueuePriority') {
+            if (preg_match('/[a-zA-Z]/', $this->{$attribute}) > 0) {
+                $this->addError($attribute, 'must be a number');
+            }
+            return;
+        } elseif (!is_array($this->{$attribute})) {
             $this->addError($attribute, 'invalid array');
-
             return;
         }
 

--- a/src/services/SiteCopy.php
+++ b/src/services/SiteCopy.php
@@ -294,8 +294,11 @@ class SiteCopy extends Component
             }
         }
 
+        // Get queue priority
+        $priority = (int)$this->settings->combinedSettingsQueuePriority;
+
         if (!empty($matchingSites)) {
-            Craft::$app->getQueue()->push(new SyncElementContent([
+            Craft::$app->getQueue()->priority($priority)->push(new SyncElementContent([
                 'elementId'        => (int)$entry->id,
                 'sourceSiteId'     => $elementSettings['sourceSite'],
                 'sites'            => $matchingSites,

--- a/src/templates/_cp/settings.twig
+++ b/src/templates/_cp/settings.twig
@@ -153,3 +153,12 @@
     options: [{value: 'or', label: 'OR',}, {value: 'and', label: 'AND'}, {value: 'xor', label: 'XOR'}, ],
     value: settings.combinedSettingsCheckMethod is not empty ? settings.combinedSettingsCheckMethod : null,
 }) }}
+
+{{ forms.textField({
+    label: 'Queue Job Priority'|t('site-copy-x'),
+    instructions: 'Decide the priority for the queue job handling the Site Copy. Jobs with a lower priority are executed first. Default is 1024'|t('site-copy-x'),
+    id: 'combinedSettingsQueuePriority',
+    name: 'combinedSettingsQueuePriority',
+    value: settings.combinedSettingsQueuePriority is not empty ? settings.combinedSettingsQueuePriority : 1024,
+    errors: settings.getErrors('combinedSettingsQueuePriority')
+}) }}


### PR DESCRIPTION
## Pull Request: Feature Implementation

### Why?
When someone copies an entry's content to one or more other locales, the plugin generates a queue job to do the work. Since it uses the default priority level of 1024, if there are a lot of other slow-running items in the queue (such as Blitz generation jobs), it can take a long time to run, which causes frustration for the content editors.

### How?
This PR adds a new setting option that allows administrators to set a queue priority to the plugin jobs if they desire. It defaults to 1024 which it's Craft's default.


#### Gif Tax
![priorities-priority](https://github.com/Goldinteractive/craft-sitecopy/assets/1016021/8b657a4a-9f1b-4e7e-943e-29ea94a42bce)
