### PR TITLE
Fix #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to be copied to a specific site.
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0 or later.
+This plugin requires Craft CMS 4.5.11 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "type": "craft-plugin",
   "minimum-stability": "dev",
   "require": {
-    "craftcms/cms": "^4.0.0"
+    "craftcms/cms": "^4.5.11"
   },
   "autoload": {
     "psr-4": {

--- a/src/services/SiteCopy.php
+++ b/src/services/SiteCopy.php
@@ -20,6 +20,7 @@ use craft\helpers\ElementHelper;
 use craft\models\Site;
 use Exception;
 use goldinteractive\sitecopy\jobs\SyncElementContent;
+use goldinteractive\sitecopy\models\SettingsModel;
 use Throwable;
 
 /**
@@ -30,7 +31,7 @@ use Throwable;
 class SiteCopy extends Component
 {
     /**
-     * @var Model|null
+     * @var SettingsModel|null
      */
     private $settings = null;
 


### PR DESCRIPTION
Makes a couple improvements to avoid race conditions where the sync queue job triggers before the initial save request is fully done processing:

- The sync job is no longer added to the queue until the end of the request (using `Craft::$app->onAfterRequest()`, which wasn’t added until Craft 4.5.11, so bumped your `craftcms/cms` requirement as well).
- The sync job now acquires a mutex lock for the element before saving it.


## Related issues

- Fixes #9
- Fixes craftcms/cms#7598
- Fixes craftcms/cms#14122