### PR TITLE
feat: include variant title

### DIFF
--- a/src/jobs/SyncElementContent.php
+++ b/src/jobs/SyncElementContent.php
@@ -79,7 +79,11 @@ class SyncElementContent extends BaseJob
                 $variantFields = [];
 
                 foreach ($sourceElement->getVariants() as $variant) {
-                    $variantFields[$variant->id] = $variant->getFieldValues();
+                    $variantFields[$variant->id]['custom_fields'] = $variant->getFieldValues();
+                    
+                    if (in_array('title', $this->attributesToCopy)) {
+                        $variantFields[$variant->id]['title'] = $variant->title;
+                    }
                 }
 
                 $tmp = $variantFields;
@@ -114,8 +118,12 @@ class SyncElementContent extends BaseJob
 
                         if ($variant) {
                             // Remap linked elements in variant fields
-                            $value = $this->remapLinkedElements($value, $this->sourceSiteId, $siteId, $variant);
-                            $variant->setFieldValues($value);
+                            $value = $this->remapLinkedElements($value['custom_fields'], $this->sourceSiteId, $siteId, $variant);
+                            $variant->setFieldValues($value['custom_fields']);
+
+                            if (isset($value['title'])) {
+                                $variant->title = $value['title'];
+                            }
 
                             $variant->setScenario(Element::SCENARIO_ESSENTIALS);
                             Craft::$app->getElements()->saveElement($variant);


### PR DESCRIPTION
Hi @francescocolazzo,

It's great to see some activity on this project again after about a year.

While cleaning up the repository, it looks like my previous PR was inadvertently closed when the craft-5 branch was deleted. As a result, I'm resubmitting the proposed changes.

This PR adds support for including a variant's title when copying entries, provided that title copying is enabled in the plugin settings.